### PR TITLE
Added initial FeatureFlag component and test

### DIFF
--- a/src/FeatureFlag.js
+++ b/src/FeatureFlag.js
@@ -1,0 +1,68 @@
+import React, { Component, PropTypes } from "react";
+import Cookies from "cookies-js";
+
+import { ldBrowserInit } from "lib/launchDarkly";
+
+export default class FeatureFlag extends Component {
+  static propTypes = {
+    flagKey: PropTypes.string.isRequired,
+    renderFeatureCallback: PropTypes.func.isRequired,
+    renderDefaultCallback: PropTypes.func,
+    initialRenderCallback: PropTypes.func
+  };
+
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      checkFeatureFlagComplete: false,
+      showFeature: false
+    };
+  }
+
+  componentDidMount () {
+    this._checkFeatureFlag();
+  }
+
+  render () {
+    return (
+      <div data-qa={`FeatureFlag-${this.props.flagKey}`}>{ this._renderLogic() }</div>
+    );
+  }
+
+  _renderLogic () {
+    const { showFeature, checkFeatureFlagComplete } = this.state;
+    const { renderFeatureCallback, renderDefaultCallback, initialRenderCallback } = this.props;
+
+    if (showFeature) {
+      return renderFeatureCallback();
+    } else if (checkFeatureFlagComplete && renderDefaultCallback) {
+      return renderDefaultCallback();
+    }
+
+    if (initialRenderCallback) {
+      return initialRenderCallback();
+    }
+
+    return null;
+  }
+
+  _checkFeatureFlag () {
+    // TODO: Investigate how we want to handle tracking users. We may want to let BE control the
+    // user keys for LD and load it from the initial state.
+    const userKey = { key: Cookies.get("u") };
+    const ldClient = ldBrowserInit(userKey);
+    const { flagKey } = this.props;
+
+    ldClient.on("ready", () => {
+      const showFeature = ldClient.variation(flagKey, false);
+      const defaultState = { checkFeatureFlagComplete: true };
+
+      if (showFeature) {
+        this.setState({ showFeature: true, ...defaultState });
+      } else {
+        this.setState({ showFeature: false, ...defaultState });
+      }
+    });
+  }
+}

--- a/test/FeatureFlag.test.js
+++ b/test/FeatureFlag.test.js
@@ -1,0 +1,174 @@
+/*global React*/
+/*global describe it*/
+/*global expect*/
+import FeatureFlag from "components/common/FeatureFlag";
+import { shallow, mount } from "enzyme";
+import * as launchDarkly from "lib/launchDarkly";
+
+describe("<FeatureFlag />", () => {
+  const renderFeatureCallback = sinon.stub().returns("feature rendered");
+  const renderDefaultCallback = sinon.stub().returns("default rendered");
+  const initialRenderCallback = sinon.stub().returns("initial rendered");
+
+  it("renders without an issue", () => {
+    const wrapper = shallow(
+      <FeatureFlag
+        flagKey="my-test"
+        renderFeatureCallback={renderFeatureCallback}
+      />
+    );
+    expect(wrapper).to.exist;
+  });
+
+  it("renders the proper data-qa attribute", () => {
+    const wrapper = shallow(
+      <FeatureFlag
+        flagKey="my-test"
+        renderFeatureCallback={renderFeatureCallback}
+      />
+    );
+    expect(wrapper.find("[data-qa='FeatureFlag-my-test']")).to.exist;
+  });
+
+  it("calls componentDidMount", () => {
+    sinon.spy(FeatureFlag.prototype, "componentDidMount");
+    mount(
+      <FeatureFlag
+        flagKey="my-test"
+        renderFeatureCallback={renderFeatureCallback}
+      />
+    );
+    expect(FeatureFlag.prototype.componentDidMount).to.have.property("callCount", 1);
+  });
+
+  describe("the _renderLogic function", () => {
+    context("when showFeature is true", () => {
+      it("renders the feature callback", () => {
+        const wrapper = shallow(
+          <FeatureFlag
+            flagKey="my-test"
+            renderFeatureCallback={renderFeatureCallback}
+          />
+        );
+        wrapper.setState({ showFeature: true });
+        expect(wrapper.text()).to.equal(renderFeatureCallback());
+      });
+    });
+
+    context("when showFeature is false", () => {
+      context("when checkFeatureFlagComplete is true", () => {
+        context("when renderDefaultCallback is provided", () => {
+          it("renders the default callback", () => {
+            const wrapper = shallow(
+              <FeatureFlag
+                flagKey="my-test"
+                renderFeatureCallback={renderFeatureCallback}
+                renderDefaultCallback={renderDefaultCallback}
+              />
+            );
+            wrapper.setState({ showFeature: false, checkFeatureFlagComplete: true });
+            expect(wrapper.text()).to.equal(renderDefaultCallback());
+          });
+        });
+
+        context("when renderDefaultCallback is not provided", () => {
+          it("renders nothing", () => {
+            const wrapper = shallow(
+              <FeatureFlag
+                flagKey="my-test"
+                renderFeatureCallback={renderFeatureCallback}
+              />
+            );
+            wrapper.setState({ showFeature: false, checkFeatureFlagComplete: true });
+            wrapper.setProps({ renderDefaultCallback: null });
+            expect(wrapper.text()).to.equal("");
+          });
+        });
+      });
+
+      context("when checkFeatureFlagComplete is false", () => {
+        context("when initialRenderCallback is provided", () => {
+          it("renders the initial callback", () => {
+            const wrapper = shallow(
+              <FeatureFlag
+                flagKey="my-test"
+                renderFeatureCallback={renderFeatureCallback}
+                initialRenderCallback={initialRenderCallback}
+              />
+            );
+            wrapper.setState({ showFeature: false, checkFeatureFlagComplete: false });
+            expect(wrapper.text()).to.equal(initialRenderCallback());
+          });
+        });
+
+        context("when initialRenderCallback is not provided", () => {
+          it("renders nothing", () => {
+            const wrapper = shallow(
+              <FeatureFlag
+                flagKey="my-test"
+                renderFeatureCallback={renderFeatureCallback}
+              />
+            );
+            wrapper.setState({ showFeature: false, checkFeatureFlagComplete: false });
+            wrapper.setProps({ initialRenderCallback: null });
+            expect(wrapper.text()).to.equal("");
+          });
+        });
+      });
+    });
+
+    context("when all else fails", () => {
+      it("it renders nothing", () => {
+        const wrapper = shallow(
+          <FeatureFlag
+            flagKey="my-test"
+            renderFeatureCallback={renderFeatureCallback}
+          />
+        );
+        wrapper.setState({ showFeature: false, checkFeatureFlagComplete: false });
+        wrapper.setProps({ renderDefaultCallback: null, initialRenderCallback: null });
+        expect(wrapper.text()).to.equal("");
+      });
+    });
+  });
+
+  describe("the _checkFeatureFlag function", () => {
+    before(() => {
+      const variation = sinon.stub();
+      variation.onCall(0).returns(true);
+      variation.onCall(1).returns(false);
+
+      const ldClientStub = sinon.stub().returns({
+        on: (ready, callback) => {
+          callback();
+        },
+        variation: variation
+      });
+      sinon.stub(launchDarkly, "ldBrowserInit", ldClientStub);
+    });
+
+    context("when the feature flag comes back true", () => {
+      it("sets the state", () => {
+        const wrapper = mount(
+          <FeatureFlag
+            flagKey="my-test"
+            renderFeatureCallback={renderFeatureCallback}
+          />
+        );
+        expect(wrapper.state()).to.deep.equal({ checkFeatureFlagComplete: true, showFeature: true });
+      });
+    });
+
+    context("when the feature flag comes back false", () => {
+      it("sets the state", () => {
+        const wrapper = mount(
+          <FeatureFlag
+            flagKey="my-test"
+            renderFeatureCallback={renderFeatureCallback}
+          />
+        );
+        expect(wrapper.state()).to.deep.equal({ checkFeatureFlagComplete: true, showFeature: false });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is a copy from our internal usage of the FeatureFlag component within one of consumer apps. We'll need to make some changes to ensure this component stays generic:
- Relies on `cookies-js` library, needed in our specific case to read cookie values to determine a user's key. This may need to be revisited in our usage as well.
- Proper port over of `lib/launchDarkly` to setup the launch darkly client. In its current state, its tightly coupled to the way we have our consumer gluestick app setup.
- Refactor `_checkFeatureFlag()` to build out the user key in a more dynamic fashion.
