### PR TITLE
Add functionality to get all feature flags for a user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-launch-darkly",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "main": "./build/index",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export LaunchDarkly from "./components/LaunchDarkly";
 export FeatureFlag from "./components/FeatureFlag";
-
+export { getAllFeatureFlags } from "./lib/launchDarkly";

--- a/src/lib/launchDarkly.js
+++ b/src/lib/launchDarkly.js
@@ -6,5 +6,9 @@ export function ldBrowserInit (key, user) {
 
 export function getAllFeatureFlags (key, user) {
   const ldClient = ldBrowserInit(key, user);
-  return ldClient.allFlags();
+  return new Promise((resolve, reject) => {
+    ldClient.on("ready", () => {
+      resolve(ldClient.allFlags());
+    });
+  });
 }

--- a/src/lib/launchDarkly.js
+++ b/src/lib/launchDarkly.js
@@ -4,3 +4,7 @@ export function ldBrowserInit (key, user) {
   return launchDarklyBrowser.initialize(key, user);
 }
 
+export function getAllFeatureFlags (key, user) {
+  const ldClient = ldBrowserInit(key, user);
+  return ldClient.allFlags();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,6 +1544,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flow-bin@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.33.0.tgz#ef011eace7a6100f1ae08b852db78279032b8750"
+
 for-in@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.6.tgz#c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8"
@@ -2747,7 +2751,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@~2.5.1, rimraf@~2.5.4, rimraf@2:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@~2.5.1, rimraf@~2.5.4, rimraf@2:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:


### PR DESCRIPTION
Adds and exposes a simple function for retrieving all feature flags for a user.

Usage may be along the lines of:
```javascript
import { getAllFeatureFlags } from "react-launch-darkly";

....

export async function allFeatureFlags(launchDarklyClientKey, user) {
  const allFlags = await getAllFeatureFlags(launchDarklyClientKey, user);
  console.log(`allFlags: ${JSON.stringify(allFlags)}`);
  // Do something here with all the flags...
}
```