### PR TITLE
move to functional stateless components for FeatureFlag and LaunchDarkly

### DIFF
--- a/src/components/FeatureFlag.js
+++ b/src/components/FeatureFlag.js
@@ -1,26 +1,22 @@
 /* @flow */
-import React, { Component } from "react";
+import React from "react";
 import { Subscriber } from "react-broadcast";
 
 import { BROADCAST_CHANNEL } from "../constants/LaunchDarkly.js";
 import FeatureFlagRenderer from "./FeatureFlagRenderer";
 import { FeatureFlagType } from "../types/FeatureFlag";
 
-export default class FeatureFlag extends Component {
-  props: FeatureFlagType;
-
-  render () {
-    return (
-      <Subscriber channel={BROADCAST_CHANNEL}>
-        { (launchDarklyConfig) => (
-            <FeatureFlagRenderer
-              launchDarklyConfig={launchDarklyConfig}
-              {...this.props}
-            />
-          )
-        }
-      </Subscriber>
-    );
-  }
+export default function FeatureFlag (props:FeatureFlagType) {
+  return (
+    <Subscriber channel={BROADCAST_CHANNEL}>
+      { (launchDarklyConfig) => (
+          <FeatureFlagRenderer
+            launchDarklyConfig={launchDarklyConfig}
+            {...props}
+          />
+        )
+      }
+    </Subscriber>
+  );
 }
 

--- a/src/components/LaunchDarkly.js
+++ b/src/components/LaunchDarkly.js
@@ -1,29 +1,27 @@
 /* @flow */
-import React, { Component } from "react";
+import React from "react";
 import { Broadcast } from "react-broadcast";
 
 import { BROADCAST_CHANNEL } from "../constants/LaunchDarkly.js";
 import { UserType } from "../types/User";
 
-export default class LaunchDarkly extends Component {
-  props: {
-    clientId: Object,
-    user: UserType,
-    children: any
+type Props = {
+  clientId: Object,
+  user: UserType,
+  children: any
+};
+
+export default function LaunchDarkly (props:Props) {
+  const { clientId, user, children } = props;
+  const value = {
+    clientId,
+    user
   };
 
-  render () {
-    const { clientId, user } = this.props;
-    const value = {
-      clientId,
-      user
-    };
-
-    return (
-      <Broadcast channel={BROADCAST_CHANNEL} value={value}>
-        {this.props.children}
-      </Broadcast>
-    );
-  }
+  return (
+    <Broadcast channel={BROADCAST_CHANNEL} value={value}>
+      {children}
+    </Broadcast>
+  );
 }
 


### PR DESCRIPTION
Since the FeatureFlag and LaunchDarkly components are not using any
local state there is a performance advantage of converting them to
simple stateless functional components. It also makes for less code as
well.