### PR TITLE
Refactor ldClientWrapper initialization

### DIFF
--- a/src/components/FeatureFlag.js
+++ b/src/components/FeatureFlag.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { Subscriber } from "react-broadcast";
 
+import { ldClientWrapper } from "../lib/utils";
 import { BROADCAST_CHANNEL } from "../constants/LaunchDarkly.js";
 import FeatureFlagRenderer from "./FeatureFlagRenderer";
 import { FeatureFlagType } from "../types/FeatureFlag";
@@ -10,9 +11,12 @@ export default function FeatureFlag (props:FeatureFlagType) {
   return (
     <Subscriber channel={BROADCAST_CHANNEL}>
       {
-        (ldClientWrapper) => {
-          if (ldClientWrapper) {
-            return (<FeatureFlagRenderer ldClientWrapper={ldClientWrapper} {...props} />);
+        (config) => {
+          if (config) {
+            const { clientId, user } = config;
+            const ldClient = ldClientWrapper(clientId, user);
+
+            return (<FeatureFlagRenderer ldClientWrapper={ldClient} {...props} />);
           }
 
           return null;

--- a/src/components/LaunchDarkly.js
+++ b/src/components/LaunchDarkly.js
@@ -2,7 +2,6 @@
 import React from "react";
 import { Broadcast } from "react-broadcast";
 
-import { ldClientWrapper } from "../lib/utils";
 import { BROADCAST_CHANNEL } from "../constants/LaunchDarkly.js";
 import { UserType } from "../types/User";
 
@@ -14,10 +13,13 @@ type Props = {
 
 export default function LaunchDarkly (props:Props) {
   const { clientId, user, children } = props;
-  const ldClient = ldClientWrapper(clientId, user);
+  const config = {
+    clientId,
+    user
+  };
 
   return (
-    <Broadcast channel={BROADCAST_CHANNEL} value={ldClient}>
+    <Broadcast channel={BROADCAST_CHANNEL} value={config}>
       {children}
     </Broadcast>
   );

--- a/test/components/LaunchDarkly.test.js
+++ b/test/components/LaunchDarkly.test.js
@@ -5,7 +5,6 @@ import LaunchDarkly from "../../src/components/LaunchDarkly";
 import FeatureFlag from "../../src/components/FeatureFlag";
 import FeatureFlagRenderer from "../../src/components/FeatureFlagRenderer";
 import { BROADCAST_CHANNEL } from "../../src/constants/LaunchDarkly";
-import * as utils from "../../src/lib/utils";
 
 describe("components/LaunchDarkly", () => {
   it("should setup a broadcast with on the correct channel", () => {
@@ -19,15 +18,21 @@ describe("components/LaunchDarkly", () => {
     expect(broadcast.prop("channel")).toEqual(BROADCAST_CHANNEL);
   });
 
-  it("should pass ldClient as the value to the broadcast", () => {
+  it("should pass config object as the value to the broadcast", () => {
+    const expectedConfig = {
+      clientId: "12345",
+      user: {
+        key: "user123"
+      }
+    };
     const subject = shallow(
-      <LaunchDarkly clientId="080808" user="zeke">
+      <LaunchDarkly clientId={expectedConfig.clientId} user={expectedConfig.user}>
         <div>Hi</div>
       </LaunchDarkly>
     );
 
     const broadcast = subject.find(Broadcast);
-    expect(broadcast.prop("value")).toEqual(utils.ldClientWrapper());
+    expect(broadcast.prop("value")).toEqual(expectedConfig);
   });
 
   it("should render the children", () => {


### PR DESCRIPTION
### Problem
When using the `LaunchDarkly` component in a universal app, the rendering of `LaunchDarkly` may occur server-side. This poses a problem since `ldclient-js` is only for the browser. It uses `XMLHttpRequest` which is not available in node. For reference, this wasn't an issue prior to 0.0.9. However, in 0.0.9, we moved the client initialization into the  `LaunchDarkly` component.

### Solution
Moving the initialization of the client into the `FeatureFlag` component, we can ensure that the `LaunchDarkly` component can continue to be used at the top-most level in your component hierarchy.