### PR TITLE
Bugfix: Handle Multiple Ready Calls

### DIFF
--- a/src/components/FeatureFlagRenderer.js
+++ b/src/components/FeatureFlagRenderer.js
@@ -53,13 +53,13 @@ export default class FeatureFlagRenderer extends Component {
     const { ldClientWrapper, flagKey } = this.props;
 
     ldClientWrapper.on("ready", () => {
-      const flagValue = ldClientWrapper.variation( flagKey, false);
+      const flagValue = ldClientWrapper.variation(flagKey, false);
       const typeFlagValue = typeof flagValue;
       const defaultState = { checkFeatureFlagComplete: true };
       const override = ldOverrideFlag(flagKey, typeFlagValue);
 
-      if (typeof override !== "undefined"){
-        this.setState({ flagValue: override, ...defaultState});
+      if (typeof override !== "undefined") {
+        this.setState({ flagValue: override, ...defaultState });
       } else if (flagValue) {
         this.setState({ flagValue: flagValue, ...defaultState });
       } else {

--- a/src/components/FeatureFlagRenderer.js
+++ b/src/components/FeatureFlagRenderer.js
@@ -52,7 +52,7 @@ export default class FeatureFlagRenderer extends Component {
   _checkFeatureFlag () {
     const { ldClientWrapper, flagKey } = this.props;
 
-    ldClientWrapper.on("ready", () => {
+    ldClientWrapper.onReady(() => {
       const flagValue = ldClientWrapper.variation(flagKey, false);
       const typeFlagValue = typeof flagValue;
       const defaultState = { checkFeatureFlagComplete: true };

--- a/test/components/FeatureFlagRenderer.test.js
+++ b/test/components/FeatureFlagRenderer.test.js
@@ -17,7 +17,7 @@ describe("components/FeatureFlagRenderer", () => {
   beforeEach(() => {
     utils.ldClientWrapper = jest.fn();
     utils.ldClientWrapper.mockImplementation(() => ({
-      on: (ready, callback) => {
+      onReady: (callback) => {
         callback();
       },
       variation

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -12,14 +12,18 @@ describe("lib/utils", () => {
     const key = "my key";
     const user = "my user";
 
+    launchDarklyBrowser.initialize = jest.fn().mockImplementation(() => ({
+      on: (event, callback) => {
+        callback();
+      }
+    }));
+
     it("proxies to ldclient-js", () => {
-      launchDarklyBrowser.initialize = jest.fn();
       utils.ldClientWrapper(key, user);
       expect(launchDarklyBrowser.initialize).toBeCalledWith(key, user);
     });
 
     it("does not instantiate ldclient-js more than once", () => {
-      launchDarklyBrowser.initialize = jest.fn(() => ({}));
       utils.ldClientWrapper(key, user);
       utils.ldClientWrapper(key, user);
       utils.ldClientWrapper(key, user);


### PR DESCRIPTION
## Problem
LaunchDarkly's js client `on('ready', () => {})` function seems to only fire upon initialization of the client and will not re-fire for subsequent calls. This is problematic for the `FeatureFlagRenderer` component since it will call it each time it is rendered.

## Solution
Keep track of the state of the client and queue up any events that need to fire. Longterm, we need to use redux or something to manage state better.