### PR TITLE
improve async support for LaunchDarkly

### DIFF
--- a/src/components/LaunchDarkly.js
+++ b/src/components/LaunchDarkly.js
@@ -13,10 +13,18 @@ type Props = {
 
 export default function LaunchDarkly (props:Props) {
   const { clientId, user, children } = props;
-  const config = {
-    clientId,
-    user
-  };
+
+  let config = null;
+
+  // if clientId or user do not exist we still want to
+  // render the Broadcast component but we want value
+  // to be null.
+  if (clientId && user) {
+    config = {
+      clientId,
+      user
+    };
+  }
 
   return (
     <Broadcast channel={BROADCAST_CHANNEL} value={config}>

--- a/test/components/LaunchDarkly.test.js
+++ b/test/components/LaunchDarkly.test.js
@@ -46,6 +46,23 @@ describe("components/LaunchDarkly", () => {
     expect(child.text()).toEqual("Hi");
   });
 
+  it("should render Broadcast with a value of null when either clientId or user are missing", () => {
+    // with neither
+    let subject = shallow(<LaunchDarkly><div>Hi</div></LaunchDarkly>);
+    let child = subject.find("Broadcast");
+    expect(child.props().value).toEqual(null);
+
+    // with clientId
+    subject = shallow(<LaunchDarkly clientId="asdf"><div>Hi</div></LaunchDarkly>);
+    child = subject.find("Broadcast");
+    expect(child.props().value).toEqual(null);
+
+    // with user
+    subject = shallow(<LaunchDarkly user={{name: "Kelly Slater"}}><div>Hi</div></LaunchDarkly>);
+    child = subject.find("Broadcast");
+    expect(child.props().value).toEqual(null);
+  });
+
   // No longer a valid concern since we are not passing the clientId or user to any of the children.
   // Instead the ldClient is initialized in the LaunchDarkly component and passed down.
   // Keeping this test for now in case we need to alter it for some other concern.


### PR DESCRIPTION
Because loading the user can be async, react-launch-darkly needs to
support a state prior to loading the user.