### PR TITLE
Remove shouldComponentUpdate

### DIFF
--- a/src/components/FeatureFlagRenderer.js
+++ b/src/components/FeatureFlagRenderer.js
@@ -27,13 +27,6 @@ export default class FeatureFlagRenderer extends Component {
     this.listenFlagChangeEvent();
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
-    return (
-      nextState.flagValue !== this.state.flagValue ||
-      nextState.checkFeatureFlagComplete !== this.state.checkFeatureFlagComplete
-    );
-  }
-
   render () {
     return this.renderLogic();
   }


### PR DESCRIPTION
This blocks any components contained within the callback props to re-render upon their state change.