### PR TITLE
Feature: Identify prop

### DIFF
--- a/src/components/FeatureFlag.js
+++ b/src/components/FeatureFlag.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { Subscriber } from "react-broadcast";
 
-import type { FeatureFlagType } from "../types";
+import type { FeatureFlagType, ConfigType } from "../types";
 import { BROADCAST_CHANNEL } from "../constants/LaunchDarkly";
 import FeatureFlagRenderer from "./FeatureFlagRenderer";
 
@@ -10,7 +10,7 @@ export default function FeatureFlag (props:FeatureFlagType) {
   return (
     <Subscriber channel={BROADCAST_CHANNEL}>
       {
-        (config) => {
+        (config:ConfigType) => {
           if (config) {
             return (<FeatureFlagRenderer {...config} {...props} />);
           }

--- a/src/components/FeatureFlagRenderer.js
+++ b/src/components/FeatureFlagRenderer.js
@@ -1,13 +1,19 @@
 // @flow
 import { Component } from "react";
 
-import type { FeatureFlagType, ConfigType, LdClientWrapperType, FlagValueType } from "../types";
+import type {
+  FeatureFlagType,
+  ConfigType,
+  LdClientWrapperType,
+  FlagValueType,
+  IdentifyType
+} from "../types";
 import { ldClientWrapper, ldOverrideFlag } from "../lib/utils";
 
 type Props = FeatureFlagType & ConfigType;
 type State = {
   checkFeatureFlagComplete: boolean,
-  flagValue: any
+  flagValue: FlagValueType
 };
 
 export default class FeatureFlagRenderer extends Component<Props, State> {
@@ -42,6 +48,7 @@ export default class FeatureFlagRenderer extends Component<Props, State> {
 
     this.checkFeatureFlag(ldClient);
     this.listenFlagChangeEvent(ldClient);
+    this.identify(ldClient);
   }
 
   componentWillUnmount () {
@@ -84,6 +91,17 @@ export default class FeatureFlagRenderer extends Component<Props, State> {
     ldClient.on(`change:${flagKey}`, (value) => {
       this.setStateFlagValue(value);
     });
+  }
+
+  identify (ldClient: LdClientWrapperType) {
+    if (this.props.identify) {
+      const { user, identify } = this.props;
+      const mergedUser:IdentifyType = Object.assign(user, identify);
+
+      ldClient.onReady(() => {
+        ldClient.identify(mergedUser, identify.hash || null);
+      });
+    }
   }
 
   setStateFlagValue (flagValue:FlagValueType) {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -2,14 +2,16 @@
 export type LdClientWrapperType = {
   on: (string, (FlagValueType) => (void)) => void,
   onReady: (() => void) => void,
-  variation: (string, boolean) => FlagValueType
+  variation: (string, boolean) => FlagValueType,
+  identify: (Object, Object | null) => void
 };
 
 export type FeatureFlagType = {
   flagKey: string,
   renderFeatureCallback: (FlagValueType) => ?React$Element<any>,
   renderDefaultCallback?: () => ?React$Element<any>,
-  initialRenderCallback?: () => ?React$Element<any>
+  initialRenderCallback?: () => ?React$Element<any>,
+  identify?: IdentifyType
 };
 
 export type ConfigType = {
@@ -43,4 +45,13 @@ export type ClientOptionsType = {
   streamUrl?: string,
 
   disableClient?: boolean
+};
+
+export type IdentifyType = {
+  key?: string,
+  firstName?: string,
+  lastName?: string,
+  email?: string,
+  custom: Object,
+  hash?: Object
 };


### PR DESCRIPTION
The current addition of `identify` via the exported `utils` is a bit cumbersome to setup and doesn't really follow the same flow when working with the component helpers.

In an attempt to improve upon this, an `identify` prop can be supplied to the `FeatureFlag` component. The `identify` prop takes in a user object, the same type defined here: https://github.com/TrueCar/react-launch-darkly#user--object-required. The main difference is you are not required to supply all of the properties, only the new properties you wish to re-identify the user to have.

```
<FeatureFlag identify={{ custom: { authenticated: true } }} />
```