### PR TITLE
Empty out onReady queue with execution (fix safari stack size exceeded bug with identify use)

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -21,9 +21,11 @@ export function ldClientWrapper (key, user, options = {}) {
     ldClient.on("ready", () => {
       ldClientReady = true;
 
-      while (queue.length) {
-        queue.shift()();
-      };
+      if (queue.length) {
+        while (queue.length) {
+          queue.shift()();
+        }
+      }
     });
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -21,11 +21,9 @@ export function ldClientWrapper (key, user, options = {}) {
     ldClient.on("ready", () => {
       ldClientReady = true;
 
-      if (queue.length) {
-        queue.forEach((callback) => {
-          callback();
-        });
-      }
+      while (queue.length) {
+        queue.shift()();
+      };
     });
   }
 


### PR DESCRIPTION
Resolves https://github.com/TrueCar/react-launch-darkly/issues/82 . 

On Safari, the ldClient's `ready` event is fired multiple times, resulting in the queue being executed successively each time. To resolve, we empty out the queue after each callback is executed.