### PR TITLE
ldClient as peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-launch-darkly",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -101,9 +101,10 @@
       "dev": true
     },
     "Base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-1.0.0.tgz",
-      "integrity": "sha1-trc+40LOZL9m1gA6RTZoO/ijSbU="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-1.0.1.tgz",
+      "integrity": "sha1-3vRcxQyWG8yb8jIdD1K8v+wfG7E=",
+      "dev": true
     },
     "abab": {
       "version": "2.0.0",
@@ -3201,7 +3202,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.11.0",
@@ -6518,11 +6520,12 @@
       }
     },
     "ldclient-js": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ldclient-js/-/ldclient-js-1.1.12.tgz",
-      "integrity": "sha512-QIOyVxQCV8Ao+Epk2sVDZzDWxwvRoaV1aCIxPEArGF5i3Fkbcjk14V6BJ2wLAJCl9xQUy0VqDWbS5qxY06iWIA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ldclient-js/-/ldclient-js-2.7.1.tgz",
+      "integrity": "sha512-5RfPWPsOo0h0Wa3xrZw/MYRYZNHoifRZ+uwhRGiORqCgmRtWaxSsxrM7bkwMMe+k/1f2saxsTx8z8XxeOmGE1A==",
+      "dev": true,
       "requires": {
-        "Base64": "1.0.0",
+        "Base64": "1.0.1",
         "escape-string-regexp": "1.0.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,15 +43,14 @@
     "flow-bin": "^0.58.0",
     "flow-typed": "^2.2.3",
     "jest": "23.6.0",
+    "ldclient-js": "^2.7.1",
     "react": "16.5.0",
     "react-dom": "16.5.0",
     "react-hot-loader": "^1.3.1",
     "rimraf": "^2.5.4"
   },
-  "dependencies": {
-    "ldclient-js": "1.1.12"
-  },
   "peerDependencies": {
+    "ldclient-js": "^1.1.12 || ^2.0.0",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"
   },

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -2,7 +2,7 @@ describe("lib/utils", () => {
   jest.useFakeTimers();
 
   let utils = require("./../../src/lib/utils");
-  let ldClient = require("ldclient-js");
+  let ldClient = require("ldclient-js").default;
 
   const mockLdClient = (() => {
     ldClient.identify = jest.fn();
@@ -24,7 +24,7 @@ describe("lib/utils", () => {
 
   describe("ldClientWrapper", () => {
     const key = "my key";
-    const user = "my user";
+    const user = { key: "my user" };
     const options = { baseUrl: "http://test" };
 
     describe("proxies to ldClient", () => {
@@ -33,7 +33,7 @@ describe("lib/utils", () => {
         // to be able to properly assert each instance of `ldClientWrapper`
         jest.resetModules();
         utils = require("./../../src/lib/utils");
-        ldClient = require("ldclient-js");
+        ldClient = require("ldclient-js").default;
         mockLdClient();
       });
 


### PR DESCRIPTION
- move `ldClient` too `peerDependencies`
  - `"ldclient-js": "^1.1.12 || ^2.0.0"`
  - *NOTE* they are deprecating default import which will probably go away in next major
```
console.warn node_modules/ldclient-js/dist/ldclient.cjs.js:1
      [LaunchDarkly] "default export" is deprecated, please use "named LDClient export"
```
- fix tests to use `devDependencies` for `"ldclient-js": "^2.7.1"`
  - need to use `require("ldclient-js").default` now since they are using named exports now