### PR TITLE
Add track

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export LaunchDarkly from "./components/LaunchDarkly";
 export FeatureFlag from "./components/FeatureFlag";
-export { getAllFeatureFlags, identify } from "./lib/utils";
+export { getAllFeatureFlags, identify, track } from "./lib/utils";

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -105,3 +105,12 @@ export function identify (key, user, hash = null) {
     });
   });
 }
+
+export function track (key, user, goalKey) {
+  const ldClient = ldClientWrapper(key, user);
+  return new Promise((resolve) => {
+    ldClient.onReady(() => {
+      resolve(ldClient.track(goalKey));
+    });
+  });
+}

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -85,6 +85,14 @@ describe("lib/utils", () => {
     });
   });
 
+  describe("track", () => {
+    it("ldclient-js track is called", () => {
+      utils.track(1234, {}).then( () => {
+        expect(ldClient.track).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("ldOverrideFlag", () => {
 
   });


### PR DESCRIPTION
This pull request introduces the `track` method from `ldclient-js`.
The API is the same as for `identify` and `getAllFeatureFlags`.