### PR TITLE
Resolve warning around default export

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,4 @@
-import launchDarklyBrowser from "ldclient-js";
+import { initialize } from "ldclient-js";
 const url = require("url");
 
 export function getLocation() {
@@ -14,7 +14,7 @@ export function ldClientWrapper (key, user, options = {}) {
   const queue = [];
 
   if (!ldClient) {
-    ldClient = launchDarklyBrowser.initialize(key, user, options);
+    ldClient = initialize(key, user, options);
   }
 
   if (!ldClientReady) {
@@ -123,3 +123,7 @@ export function feature (key, user, variation) {
     });
   });
 }
+
+export const testExports = {
+  reset: () => { ldClient = null; }
+};

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -1,24 +1,21 @@
+jest.useFakeTimers();
+
+jest.mock("ldclient-js");
+
+import { initialize } from "ldclient-js";
+import * as utils from "../../src/lib/utils";
+
 describe("lib/utils", () => {
-  jest.useFakeTimers();
-
-  let utils = require("./../../src/lib/utils");
-  let ldClient = require("ldclient-js").default;
-
-  const mockLdClient = (() => {
-    ldClient.identify = jest.fn();
-
-    ldClient.initialize = jest.fn().mockImplementation(() => ({
-      on: (event, callback) => {
-        setTimeout(() => {
-          callback();
-        }, 1000);
-      },
-      variation: jest.fn,
-      track: jest.fn,
-      identify: jest.fn,
-    }));
-  });
-  mockLdClient();
+  initialize.mockImplementation(() => ({
+    on: (event, callback) => {
+      setTimeout(() => {
+        callback();
+      }, 1000);
+    },
+    variation: jest.fn,
+    track: jest.fn,
+    identify: jest.fn,
+  }));
 
   it("exports functions", () => {
     expect(utils["ldClientWrapper"]).toBeDefined();
@@ -33,22 +30,18 @@ describe("lib/utils", () => {
 
     describe("proxies to ldClient", () => {
       beforeEach(() => {
-        // `ldClientWrapper` is a singleton, we need to reset the module cache with each test
-        // to be able to properly assert each instance of `ldClientWrapper`
-        jest.resetModules();
-        utils = require("./../../src/lib/utils");
-        ldClient = require("ldclient-js").default;
-        mockLdClient();
+        jest.clearAllMocks();
+        utils.testExports.reset();
       });
 
       it("initializes with key, user and default options parameter", () => {
         utils.ldClientWrapper(key, user);
-        expect(ldClient.initialize).toBeCalledWith(key, user, {});
+        expect(initialize).toBeCalledWith(key, user, {});
       });
 
       it("initializes with key, user and options", () => {
         utils.ldClientWrapper(key, user, options);
-        expect(ldClient.initialize).toBeCalledWith(key, user, options);
+        expect(initialize).toBeCalledWith(key, user, options);
       });
     });
 
@@ -56,7 +49,7 @@ describe("lib/utils", () => {
       utils.ldClientWrapper(key, user);
       utils.ldClientWrapper(key, user);
       utils.ldClientWrapper(key, user);
-      expect(ldClient.initialize).toHaveBeenCalledTimes(1);
+      expect(initialize).toHaveBeenCalledTimes(1);
     });
 
     it("onReady calls wait for ready event to fire", () => {


### PR DESCRIPTION
With the current version of the launchdarkly client there is the
following warning:

`[LaunchDarkly] "default export" is deprecated, please use "named
LDClient export"`

This moves away from the default export and uses the named import
instead.