### PR TITLE
Safe client initialization

### DIFF
--- a/src/components/FeatureFlagRenderer.js
+++ b/src/components/FeatureFlagRenderer.js
@@ -39,7 +39,7 @@ export default class FeatureFlagRenderer extends Component<Props, State> {
     this.initializeClient();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     if (!(prevProps.user && prevProps.clientId) && (this.props.user && this.props.clientId)) {
       this.initializeClient();
     }

--- a/src/components/FeatureFlagRenderer.js
+++ b/src/components/FeatureFlagRenderer.js
@@ -32,20 +32,31 @@ export default class FeatureFlagRenderer extends Component<Props, State> {
 
     this._isMounted = true;
 
-    if (clientOptions && clientOptions.disableClient) {
+    if ((clientOptions && clientOptions.disableClient) || !(user && clientId)) {
       return;
     }
 
+    this.initializeClient();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!(prevProps.user && prevProps.clientId) && (this.props.user && this.props.clientId)) {
+      this.initializeClient();
+    }
+  }
+
+  componentWillUnmount () {
+    this._isMounted = false;
+  }
+
+  initializeClient() {
+    const { clientId, user, clientOptions } = this.props;
     // Only initialize the launch darkly js-client when in browser,
     // can not be initialized on SSR due to dependency on XMLHttpRequest.
     const ldClient = ldClientWrapper(clientId, user, clientOptions);
 
     this.checkFeatureFlag(ldClient);
     this.listenFlagChangeEvent(ldClient);
-  }
-
-  componentWillUnmount () {
-    this._isMounted = false;
   }
 
   render () {

--- a/test/components/FeatureFlagRenderer.test.js
+++ b/test/components/FeatureFlagRenderer.test.js
@@ -28,6 +28,8 @@ describe("components/FeatureFlagRenderer", () => {
       <FeatureFlagRenderer
         flagKey="my-test"
         renderFeatureCallback={renderFeatureCallback}
+        user={{}}
+        clientId="123"
         {...options}
       />,{ disableLifecycleMethods: true }
     )
@@ -35,6 +37,8 @@ describe("components/FeatureFlagRenderer", () => {
   const mountRender = (options) => (
     mount(
       <FeatureFlagRenderer
+        user={{}}
+        clientId="123"
         flagKey="my-test"
         renderFeatureCallback={renderFeatureCallback}
         {...options}


### PR DESCRIPTION
Fixes a bug in the update to `initialRenderCallback` which attempts to initialize the LD client without a user and/or client ID