### PR TITLE
switch to the new name for the ldclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 ## Dependencies
 - React `v16.3.0` or greater
   - If you use an older version of React, you can continue to use [version 1.4.0](https://github.com/TrueCar/react-launch-darkly/releases/tag/v1.4.0) of this library. However, we will no longer be actively maintaining version 1.x.
-- [LaunchDarkly client](https://docs.launchdarkly.com/docs/js-sdk-reference) / `ldclient-js`
-  - `ldclient-js` needs to be a dependency within the app using `react-launch-darkly`
-  - supported versions of `ldclient-js`: `^1.1.12 || ^2.0.0`
+- [LaunchDarkly client](https://docs.launchdarkly.com/docs/js-sdk-reference) / `launchdarkly-js-client-sdk`
+  - `launchdarkly-js-client-sdk` needs to be a dependency within the app using `react-launch-darkly`
+  - supported versions of `launchdarkly-js-client-sdk`: `^2.0.0` (peer dependency)
 
 ## Basic Usage
 To setup the `LaunchDarkly` component wrapper, you'll probably want to include it in a top-level

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "ldclient-js": "^1.1.12 || ^2.0.0",
+    "launchdarkly-js-client-sdk": "^2.0.0",
     "react": ">=16.3.0",
     "react-dom": ">=16.3.0"
   },


### PR DESCRIPTION
fulfills the request in #111 to update to the new name of the javascript client.  This should address the warnings due to older versions of the client, and should be forward-compatible.